### PR TITLE
removed `define` global

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,8 @@ export default function ({ types: t }) {
     })
   `);
 
-  const buildDefineGlobal = template(`
-     var define, global = this, GLOBAL = this;
+  const buildGlobal = template(`
+     var global = this, GLOBAL = this;
   `);
 
   const buildStaticFilePaths = template(`
@@ -117,7 +117,7 @@ export default function ({ types: t }) {
             }));
           }
 
-          node.body.unshift(buildDefineGlobal());
+          node.body.unshift(buildGlobal());
 
           let { globals } = opts;
           if (globals && Object.keys(globals).length) {


### PR DESCRIPTION
I wonder if it's a bug: there's no `define` global in CJS.

// CC @guybedford